### PR TITLE
Update image_converter.rgb_to_color565 to make converted colors more accurate.

### DIFF
--- a/utils/image_converter.py
+++ b/utils/image_converter.py
@@ -56,8 +56,10 @@ def rgb_to_color565(r, g, b):
     Returns:
         int: Converted color value in the 16-bit color format (565).
     """
-
-    return ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b & 0xF8)
+    r = ((r * 31) // (255))
+    g = ((g * 63) // (255))
+    b = ((b * 31) // (255))
+    return (r << 11) | (g << 5) | b
 
 
 def convert_to_bitmap(image_file, bits_requested):


### PR DESCRIPTION
Hello! 
I noticed while working on a project, and using your display driver, that the original `rgb_to_color565` code seems to output some inaccurate colors. 

This is easy to test by passing (255, 255, 255), which should become 0xffff, but instead becomes 0xfff8.   
I've replaced it with some code that outputs 0xffff, and otherwise just outputs more accurate colors.

The main `st7789py.py` file still uses the other implementation, but I was hesitant to change it because I haven't tested to see if there's a speed difference, or anything like that.