### PR TITLE
Working esp32-2432S028r st7789 config setup

### DIFF
--- a/tft_configs/esp32-2432S028r_st7789/tft_config.py
+++ b/tft_configs/esp32-2432S028r_st7789/tft_config.py
@@ -1,0 +1,34 @@
+""" ESP32-2432S028R 320x240 st7789 display sometimes known as "Cheap Yellow Board" (CYD) - this is the v3 board
+
+"""
+
+from machine import Pin, SPI
+import st7789py as st7789
+
+TFA = 40
+BFA = 40
+WIDE = 1
+TALL = 0
+SCROLL = 0      # orientation for scroll.py
+FEATHERS = 1    # orientation for feathers.py
+
+def config(rotation=0):
+    """
+    Configures and returns an instance of the ST7789 display driver.
+
+    Args:
+        rotation (int): The rotation of the display (default: 0).
+
+    Returns:
+        ST7789: An instance of the ST7789 display driver.
+    """
+
+    return st7789.ST7789(
+        SPI(1, baudrate=40000000, sck=Pin(14), mosi=Pin(13), miso=None),
+        240,
+        320,
+        reset=Pin(0, Pin.OUT),
+        cs=Pin(15, Pin.OUT),
+        dc=Pin(2, Pin.OUT),
+        backlight=Pin(21, Pin.OUT),
+        rotation=rotation)


### PR DESCRIPTION
aliexpress has started shipping the "Cheap Yellow Board" displays with a different driver.
Nowhere else online has anyone I've found been able to get this working with micropython yet... until now.
Here's the tested and working setup..

![front](https://github.com/user-attachments/assets/f6dcf217-9e43-4975-9ff6-56b3fb116c78)

![back](https://github.com/user-attachments/assets/72cbc79c-0041-464b-96cd-e2a8da187c82)
